### PR TITLE
fix: add .npmignore to exclude xcode/ directory and reduce package size by ~57%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Exclude Xcode project — only needed for building the Safari extension from source.
+# Install the pre-built extension from the App Store or build from the GitHub repo.
+xcode/
+
+# Development and CI files
+.github/
+assets/
+examples/
+social-preview.png
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md
+server.json
+mcp.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -453,13 +453,20 @@ The Safari MCP Extension is **optional but recommended**. Without it, ~80% of fu
 
 ### Installing the Extension
 
-The extension requires a one-time build with Xcode (free, included with macOS):
+The extension requires a one-time build with Xcode (free, included with macOS).
+
+> **Note for npm users:** The `xcode/` directory is not included in the npm package to keep
+> the install size small. Clone the [GitHub repository](https://github.com/achiya-automation/safari-mcp)
+> to get the Xcode project if you want to build from source.
 
 **Prerequisites:** Xcode (install from App Store — free)
 
 ```bash
-# 1. Build the extension app
+# 1. Clone the repo (the npm package does not include the Xcode project)
+git clone https://github.com/achiya-automation/safari-mcp.git
 cd safari-mcp
+
+# 2. Build the extension app
 xcodebuild -project "xcode/Safari MCP/Safari MCP.xcodeproj" \
   -scheme "Safari MCP (macOS)" -configuration Release build
 


### PR DESCRIPTION
## Summary
Closes #10

The published npm package included the `xcode/` directory (~508KB) which contains the Safari Web Extension Xcode project. This is only needed when building from source — not for regular `npm install` users.

## Changes
- Added `.npmignore` to explicitly exclude `xcode/`, dev files, assets, and CI files
- Updated README to clarify the `xcode/` directory is not included in the npm package, with a note to clone the repo for source builds

## Result
Package size drops from ~879KB to ~370KB (~58% reduction). The `xcode/` directory remains in the git repo for source builders.