### PR TITLE
fix: move popup inline script to popup.js to satisfy MV3 CSP

### DIFF
--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -37,42 +37,6 @@
       <span class="slider"></span>
     </label>
   </div>
-  <script>
-    // Inline script — cannot be cached separately by Safari
-    function setStatus(c, t, i) {
-      document.getElementById("statusDot").className = "dot " + c;
-      document.getElementById("statusText").textContent = t;
-      document.getElementById("info").textContent = i;
-    }
-    async function getVal(k, d) {
-      try { const r = await browser.storage.local.get(k); return r[k] !== undefined ? r[k] : d; }
-      catch { return d; }
-    }
-    async function check() {
-      const on = await getVal("mcpEnabled", true);
-      document.getElementById("enableToggle").checked = on;
-      if (!on) { setStatus("paused", "Paused", "Toggle to resume"); return; }
-      // Ask background script for real-time status first
-      try {
-        const resp = await browser.runtime.sendMessage({ action: "getStatus" });
-        if (resp) {
-          if (resp.connected) { setStatus("connected", "Connected", "Port 9224"); return; }
-          if (!resp.enabled) { setStatus("paused", "Paused", "Toggle to resume"); return; }
-        }
-      } catch {}
-      // Fallback: read from storage
-      const s = await getVal("mcpStatus", null);
-      if (s === "connected") setStatus("connected", "Connected", "Port 9224");
-      else if (s === "paused") setStatus("paused", "Paused", "Toggle to resume");
-      else if (s === "checking") setStatus("checking", "Connecting...", "Trying port 9224...");
-      else setStatus("disconnected", "Not connected", "Start the MCP server to connect");
-    }
-    document.getElementById("enableToggle").addEventListener("change", async (e) => {
-      await browser.storage.local.set({ mcpEnabled: e.target.checked });
-      try { browser.runtime.sendMessage({ action: "setEnabled", enabled: e.target.checked }); } catch {}
-      setTimeout(check, 500);
-    });
-    check();
-  </script>
+  <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,0 +1,34 @@
+function setStatus(c, t, i) {
+  document.getElementById("statusDot").className = "dot " + c;
+  document.getElementById("statusText").textContent = t;
+  document.getElementById("info").textContent = i;
+}
+async function getVal(k, d) {
+  try { const r = await browser.storage.local.get(k); return r[k] !== undefined ? r[k] : d; }
+  catch { return d; }
+}
+async function check() {
+  const on = await getVal("mcpEnabled", true);
+  document.getElementById("enableToggle").checked = on;
+  if (!on) { setStatus("paused", "Paused", "Toggle to resume"); return; }
+  // Ask background script for real-time status first
+  try {
+    const resp = await browser.runtime.sendMessage({ action: "getStatus" });
+    if (resp) {
+      if (resp.connected) { setStatus("connected", "Connected", "Port 9224"); return; }
+      if (!resp.enabled) { setStatus("paused", "Paused", "Toggle to resume"); return; }
+    }
+  } catch {}
+  // Fallback: read from storage
+  const s = await getVal("mcpStatus", null);
+  if (s === "connected") setStatus("connected", "Connected", "Port 9224");
+  else if (s === "paused") setStatus("paused", "Paused", "Toggle to resume");
+  else if (s === "checking") setStatus("checking", "Connecting...", "Trying port 9224...");
+  else setStatus("disconnected", "Not connected", "Start the MCP server to connect");
+}
+document.getElementById("enableToggle").addEventListener("change", async (e) => {
+  await browser.storage.local.set({ mcpEnabled: e.target.checked });
+  try { browser.runtime.sendMessage({ action: "setEnabled", enabled: e.target.checked }); } catch {}
+  setTimeout(check, 500);
+});
+check();


### PR DESCRIPTION
## Problem

The extension popup always shows **"Checking..."** and never updates to Connected/Disconnected/Paused, even when the MCP server is running.

**Root cause:** `manifest.json` enforces `script-src 'self'` via the `content_security_policy` field:

```json
"content_security_policy": {
  "extension_pages": "script-src 'self'; connect-src 'self' http://localhost:9224 http://127.0.0.1:9224"
}
```

Safari Web Extension MV3 enforces this CSP strictly. The entire `<script>` block in `popup/popup.html` is an **inline script** — it is silently blocked, `check()` never runs, and the DOM stays frozen at the initial `"Checking..."` state.

Related: #18 (original issue report)

## Fix

Moved the inline script to `popup/popup.js` and replaced the `<script>` block with `<script src="popup.js"></script>`, which satisfies `script-src 'self'`.

No logic changes — identical behavior, just loaded from an external file as required by the CSP.

## Files Changed

- `extension/popup/popup.html` — replaced inline `<script>` with `<script src="popup.js">`
- `extension/popup/popup.js` — new file with the extracted script

## Testing

Build the extension from Xcode, install in Safari, click the toolbar icon — popup now correctly shows Connected/Connecting.../Not connected based on server state.