### PR TITLE
test: add smoke tests for registered MCP tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,5 @@ jobs:
           node --check index.js
           node --check safari.js
           node --check mcp-helpers.js
+
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "start": "node index.js",
+    "test": "node --test tests/smoke.test.js",
     "postinstall": "node scripts/postinstall.cjs || true"
   },
   "keywords": [

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function listRegisteredTools() {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["index.js"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      SAFARI_MCP_QUIET: "1",
+    },
+    stderr: "pipe",
+  });
+  const stderr = [];
+  transport.stderr?.on("data", (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client({ name: "safari-mcp-smoke-test", version: "0.0.0" });
+
+  try {
+    await client.connect(transport, { timeout: 10_000 });
+    return await client.listTools(undefined, { timeout: 10_000 });
+  } catch (error) {
+    const logs = stderr.join("").trim();
+    error.message = logs ? `${error.message}\nServer stderr:\n${logs}` : error.message;
+    throw error;
+  } finally {
+    await client.close().catch(() => {});
+    await transport.close().catch(() => {});
+  }
+}
+
+async function getExpectedToolCount() {
+  const source = await readFile("index.js", "utf8");
+  return source.match(/server\.tool\(/g)?.length ?? 0;
+}
+
+test("server starts and lists all registered tools", async () => {
+  const expectedToolCount = await getExpectedToolCount();
+  const { tools } = await listRegisteredTools();
+
+  assert.ok(expectedToolCount >= 80, "index.js should define at least 80 tools");
+  assert.equal(tools.length, expectedToolCount);
+});
+
+test("registered tools have valid schemas and unique names", async () => {
+  const { tools } = await listRegisteredTools();
+  const names = new Set();
+
+  for (const tool of tools) {
+    assert.equal(typeof tool.name, "string");
+    assert.match(tool.name, /^safari_[a-z0-9_]+$/);
+    assert.ok(!names.has(tool.name), `duplicate tool name: ${tool.name}`);
+    names.add(tool.name);
+
+    assert.equal(typeof tool.description, "string", `${tool.name} missing description`);
+    assert.ok(tool.description.trim().length > 0, `${tool.name} has empty description`);
+
+    assert.equal(typeof tool.inputSchema, "object", `${tool.name} missing inputSchema`);
+    assert.equal(tool.inputSchema.type, "object", `${tool.name} inputSchema must be object`);
+    assert.equal(
+      typeof tool.inputSchema.properties,
+      "object",
+      `${tool.name} inputSchema missing properties`
+    );
+  }
+});


### PR DESCRIPTION
Closes #5

## What does this PR do?

Adds a Node built-in test runner smoke suite for the MCP server.

The tests start `index.js` through `StdioClientTransport`, the same stdio path MCP clients use, then verify:

- the server starts and responds to `tools/list`
- every `server.tool(...)` registered in `index.js` is exposed
- at least 80 tools are present; currently 91
- tool names are unique and follow the `safari_*` naming pattern
- every tool has a non-empty description and object `inputSchema`

This also adds `npm test` and runs it in the existing macOS CI matrix after syntax checks.

No runtime tool handlers, package dependencies, lockfile entries, or package `files` allowlist entries are changed.

## How to test

Ran locally:

- `npm test`
  - 2 pass, 0 fail
- `node --check index.js && node --check safari.js && node --check mcp-helpers.js && node --check tests/smoke.test.js`
- `npm audit --audit-level=high --omit=dev`
  - Passes the high+ audit gate.
  - Existing moderate `hono` advisories remain.
- MCP stdio smoke check:
  - connect
  - `ping`
  - `tools/list` => 91 tools
  - `safari_wait({ ms: 5 })` => `Waited 5ms`
- Real Safari E2E on macOS:
  - temporarily enabled Safari's **Allow JavaScript from Apple Events** setting for the test, then restored the original preference state
  - `safari_new_tab`
  - `safari_wait_for`
  - `safari_read_page`
  - `safari_fill`
  - `safari_click`
  - `safari_evaluate`
  - `safari_close_tab`

Note: I also tried `safari_screenshot`, but local macOS Screen Recording permission blocked the screenshot check. This PR does not change the screenshot handler.

## Checklist

- [x] Tested on macOS with Safari
- [x] All existing tools still work
  - Tool registration smoke covers all 91 registered tools.
  - Real Safari E2E covers startup, tab open/close, wait, read, fill, click, and evaluate paths.
  - This PR does not change existing tool handlers.
- [x] New tools have proper error handling
  - N/A; no new tools added.
- [x] README updated
  - N/A; no new tools added.
- [x] All code, comments, and commit messages in English
