### PR TITLE
chore: glama.json — 96 tools (was "80+")

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "Safari MCP Server",
-  "description": "Native Safari browser automation for AI agents. 80+ tools via AppleScript — zero overhead, keeps logins, runs silently in background.",
+  "description": "Native Safari browser automation for AI agents. 96 tools via AppleScript — zero overhead, keeps logins, runs silently in background.",
   "repository": "https://github.com/achiya-automation/safari-mcp",
   "homepage": "https://github.com/achiya-automation/safari-mcp",
   "author": "achiya-automation",


### PR DESCRIPTION
## מה זה עושה
מעדכן את שדה ה-`description` ב-`glama.json` מ-"80+ tools" ל-"96 tools".

## למה
ה-Glama listing נקרא ישירות מ-`glama.json` שב-repo (לא תלוי ב-npm release), אז התיאור מתעדכן ברגע שזה מתמזג ל-main. v2.14.0 הביא את הספירה ל-**96 tools** — אומת מול המקור (`grep` של שמות `safari_*` = 96) וגם מול ה-smoke test שסופר `server.tool(`.

## בטיחות
שינוי מטא-דאטה בלבד, שורה אחת. אין שינוי קוד, אין השפעה על runtime, npm test 32/32 עדיין ירוק.

🤖 Generated with [Claude Code](https://claude.com/claude-code)