### PR TITLE
refactor: extract tab-ownership state into ownership-state.js (+ behavioral tests)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,17 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import * as safari from "./safari.js";
-import { findOwnedMatch, pruneExpired } from "./ownership-match.js";
 import { textResult, jsonResult, imageResult, errorResult } from "./response.js";
+import {
+  OWNERSHIP_DIR, BLANK_TAB_SENTINEL,
+  _openedTabs, _ownedTabURLs,
+  _isURLOwned, _markBlankTabOpened, _addOwnedURL, _removeOwnedURL, _trackTab, _untrackTab,
+} from "./ownership-state.js";
 import { WebSocketServer } from "ws";
 import { createServer } from "node:http";
 import { randomUUID, randomBytes } from "node:crypto";
 import { execFile, execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, renameSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
@@ -49,130 +53,20 @@ const PROXY_TOKEN = _getProxyToken();
 // ========== SESSION ID (unique per MCP process — enables per-session tab tracking) ==========
 const SESSION_ID = randomUUID().slice(0, 8);
 
-// ========== PERSISTENT TAB OWNERSHIP ==========
-// The in-memory _ownedTabURLs set is wiped when the MCP process restarts
-// (Claude Code periodically recycles MCP servers). Without persistence, every
-// restart re-triggers "Tab safety: no tabs opened yet" errors forcing a
-// re-open of every tab. Persist the set to a JSON file with a TTL so tabs
-// remain "owned" across process restarts for up to OWNERSHIP_TTL_MS.
-const OWNERSHIP_DIR = join(homedir(), ".safari-mcp");
-const OWNERSHIP_FILE = join(OWNERSHIP_DIR, "owned-tabs.json");
-const OWNERSHIP_TTL_MS = 30 * 60 * 1000; // 30 minutes
-
-function _loadOwnershipFile() {
-  try {
-    if (!existsSync(OWNERSHIP_FILE)) return [];
-    const raw = readFileSync(OWNERSHIP_FILE, "utf8");
-    const data = JSON.parse(raw);
-    if (!Array.isArray(data)) return [];
-    const cutoff = Date.now() - OWNERSHIP_TTL_MS;
-    return data.filter(e => e && typeof e.url === "string" && typeof e.ts === "number" && e.ts > cutoff);
-  } catch { return []; }
-}
-
-function _saveOwnershipFile(urls) {
-  try {
-    if (!existsSync(OWNERSHIP_DIR)) mkdirSync(OWNERSHIP_DIR, { recursive: true });
-    const now = Date.now();
-    const entries = Array.from(urls).map(url => ({ url, ts: _ownedTabTimestamps.get(url) ?? now }));
-    // Atomic write (tmp + rename) — concurrent MCP instances share this file; a partial
-    // write from one must never corrupt the JSON another instance reads.
-    const tmp = OWNERSHIP_FILE + ".tmp." + process.pid;
-    writeFileSync(tmp, JSON.stringify(entries), { mode: 0o600 });
-    renameSync(tmp, OWNERSHIP_FILE);
-  } catch { /* best-effort */ }
-}
+// Persistent tab-ownership state + its helpers now live in ownership-state.js
+// (OWNERSHIP_* consts, _ownedTabURLs/_ownedTabTimestamps, _loadOwnershipFile,
+// _saveOwnershipFile, _isURLOwned, _addOwnedURL, _trackTab, … — imported at the top).
+// OWNERSHIP_DIR is re-used below for the memory-monitor lock file.
 
 // ========== MEMORY GUARD: track & auto-close MCP-opened tabs ==========
 const MAX_TABS = parseInt(process.env.MCP_MAX_TABS || "6", 10);
 const MEMORY_CHECK_INTERVAL_MS = parseInt(process.env.MCP_MEMORY_CHECK_MS || "60000", 10);
 const WEBKIT_MEMORY_LIMIT_MB = parseInt(process.env.MCP_WEBKIT_LIMIT_MB || "3000", 10);
 
-// Track tabs opened by THIS session (index → {url, openedAt})
-const _openedTabs = new Map();
-
-// ========== TAB OWNERSHIP: prevent operating on user's tabs ==========
-// Tracks URLs of tabs opened by this MCP session.
-// Any tool that modifies a tab (navigate, click, fill, etc.) is blocked
-// unless the current tab was opened via safari_new_tab.
-// Hydrated from ~/.safari-mcp/owned-tabs.json so ownership survives MCP restarts.
-const _ownedTabURLs = new Set();
-// Preserve each entry's ORIGINAL timestamp so _saveOwnershipFile doesn't reset it to `now` on
-// every write — otherwise the 30-min TTL never expires anything while a session is active, and
-// stale ownership leaks onto the user's tabs across sessions.
-const _ownedTabTimestamps = new Map();
-for (const e of _loadOwnershipFile()) {
-  _ownedTabURLs.add(e.url);
-  _ownedTabTimestamps.set(e.url, e.ts);
-}
-
-// Touch-on-use + live TTL enforcement. The TTL exists so ownership doesn't outlive the
-// session's actual use of a tab: entries the session keeps asserting against stay fresh;
-// abandoned entries expire after OWNERSHIP_TTL_MS and can no longer match a user's tab.
-// (Previously the TTL was only applied when loading the file at startup, so a long-lived
-// session accumulated ownership forever.)
-function _touchOwned(ownedKey) {
-  _ownedTabTimestamps.set(ownedKey, Date.now());
-  return true;
-}
-function _pruneExpiredOwnership() {
-  if (pruneExpired(_ownedTabURLs, _ownedTabTimestamps, OWNERSHIP_TTL_MS)) {
-    _saveOwnershipFile(_ownedTabURLs);
-  }
-}
-
-// Matching semantics (exact / normalized / same-origin path-prefix with a segment
-// boundary) live in ownership-match.js, where test/ownership-match.test.mjs locks
-// them — including that owning /org never owns /org-evil, and that the broad
-// "own the whole origin" rule stays dead (it defeated tab-safety entirely).
-function _isURLOwned(url) {
-  if (!url) return false;
-  _pruneExpiredOwnership();
-  const match = findOwnedMatch(url, _ownedTabURLs);
-  return match !== null ? _touchOwned(match) : false;
-}
-
-// Sentinel persisted when a blank tab (about:blank) is opened by this session.
-// A blank tab has no unique URL to own, but ownership must still survive an MCP
-// process restart (_openedTabs is in-memory only) — otherwise reopening blank
-// tabs falsely trips the "no tabs opened yet" guard. The sentinel is never a
-// real tab URL, so it cannot falsely match a user's page in _isURLOwned().
-const BLANK_TAB_SENTINEL = "__mcp-blank-tab__";
-
-function _markBlankTabOpened() {
-  if (!_ownedTabURLs.has(BLANK_TAB_SENTINEL)) {
-    _ownedTabTimestamps.set(BLANK_TAB_SENTINEL, Date.now());
-    _ownedTabURLs.add(BLANK_TAB_SENTINEL);
-    _saveOwnershipFile(_ownedTabURLs);
-  }
-}
-
-function _addOwnedURL(url) {
-  if (url && url !== 'about:blank' && url !== 'favorites://') {
-    if (!_ownedTabTimestamps.has(url)) _ownedTabTimestamps.set(url, Date.now());
-    _ownedTabURLs.add(url);
-    _saveOwnershipFile(_ownedTabURLs);
-  }
-}
-
-function _removeOwnedURL(url) {
-  if (url) {
-    _ownedTabURLs.delete(url);
-    _ownedTabTimestamps.delete(url);
-    _saveOwnershipFile(_ownedTabURLs);
-  }
-}
-
-function _trackTab(tabIndex, url) {
-  _openedTabs.set(tabIndex, { url: url || "", openedAt: Date.now() });
-  _addOwnedURL(url);
-}
-
-function _untrackTab(tabIndex) {
-  const info = _openedTabs.get(tabIndex);
-  if (info?.url) _removeOwnedURL(info.url);
-  _openedTabs.delete(tabIndex);
-}
+// Tab-ownership state (_openedTabs / _ownedTabURLs / _ownedTabTimestamps), the on-disk
+// persistence + TTL, and the helpers (_isURLOwned, _markBlankTabOpened, _addOwnedURL,
+// _removeOwnedURL, _trackTab, _untrackTab, BLANK_TAB_SENTINEL) are imported from
+// ownership-state.js at the top of this file.
 
 // Close all MCP-opened tabs on process exit
 async function _cleanupTabs() {

--- a/ownership-state.js
+++ b/ownership-state.js
@@ -1,0 +1,141 @@
+// Tab-ownership state + tracking — the security-critical core that prevents the MCP
+// session from operating on the USER's tabs. Extracted verbatim from index.js so the
+// state and its helpers live in one reviewable, test-locked module (see
+// tests/ownership-state.test.mjs). The pure matching/pruning semantics live next door in
+// ownership-match.js; this module owns the *stateful* layer on top of them: the in-memory
+// sets, the on-disk persistence (so ownership survives MCP restarts), and the TTL.
+//
+// Every symbol here was previously a module-level binding in index.js. All exported state
+// is `const` (Map/Set) — mutated, never reassigned — so ESM live bindings keep index.js and
+// any future src/tools/* module pointing at the exact same objects.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { findOwnedMatch, pruneExpired } from "./ownership-match.js";
+
+// MCP opens tabs, but a restart re-triggers "Tab safety: no tabs opened yet" errors forcing
+// a re-open of every tab. Persist the set to a JSON file with a TTL so tabs remain "owned"
+// across process restarts for up to OWNERSHIP_TTL_MS.
+export const OWNERSHIP_DIR = join(homedir(), ".safari-mcp");
+export const OWNERSHIP_FILE = join(OWNERSHIP_DIR, "owned-tabs.json");
+export const OWNERSHIP_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export function _loadOwnershipFile() {
+  try {
+    if (!existsSync(OWNERSHIP_FILE)) return [];
+    const raw = readFileSync(OWNERSHIP_FILE, "utf8");
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    const cutoff = Date.now() - OWNERSHIP_TTL_MS;
+    return data.filter(
+      (e) => e && typeof e.url === "string" && typeof e.ts === "number" && e.ts > cutoff
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function _saveOwnershipFile(urls) {
+  try {
+    if (!existsSync(OWNERSHIP_DIR)) mkdirSync(OWNERSHIP_DIR, { recursive: true });
+    const now = Date.now();
+    const entries = Array.from(urls).map((url) => ({
+      url,
+      ts: _ownedTabTimestamps.get(url) ?? now,
+    }));
+    // Atomic write (tmp + rename) — concurrent MCP instances share this file; a partial
+    // write from one must never corrupt the JSON another instance reads.
+    const tmp = OWNERSHIP_FILE + ".tmp." + process.pid;
+    writeFileSync(tmp, JSON.stringify(entries), { mode: 0o600 });
+    renameSync(tmp, OWNERSHIP_FILE);
+  } catch {
+    /* best-effort */
+  }
+}
+
+// Track tabs opened by THIS session (index → {url, openedAt})
+export const _openedTabs = new Map();
+
+// ========== TAB OWNERSHIP: prevent operating on user's tabs ==========
+// Tracks URLs of tabs opened by this MCP session.
+// Any tool that modifies a tab (navigate, click, fill, etc.) is blocked
+// unless the current tab was opened via safari_new_tab.
+// Hydrated from ~/.safari-mcp/owned-tabs.json so ownership survives MCP restarts.
+export const _ownedTabURLs = new Set();
+// Preserve each entry's ORIGINAL timestamp so _saveOwnershipFile doesn't reset it to `now` on
+// every write — otherwise the 30-min TTL never expires anything while a session is active, and
+// stale ownership leaks onto the user's tabs across sessions.
+export const _ownedTabTimestamps = new Map();
+for (const e of _loadOwnershipFile()) {
+  _ownedTabURLs.add(e.url);
+  _ownedTabTimestamps.set(e.url, e.ts);
+}
+
+// Touch-on-use + live TTL enforcement. The TTL exists so ownership doesn't outlive the
+// session's actual use of a tab: entries the session keeps asserting against stay fresh;
+// abandoned entries expire after OWNERSHIP_TTL_MS and can no longer match a user's tab.
+// (Previously the TTL was only applied when loading the file at startup, so a long-lived
+// session accumulated ownership forever.)
+export function _touchOwned(ownedKey) {
+  _ownedTabTimestamps.set(ownedKey, Date.now());
+  return true;
+}
+export function _pruneExpiredOwnership() {
+  if (pruneExpired(_ownedTabURLs, _ownedTabTimestamps, OWNERSHIP_TTL_MS)) {
+    _saveOwnershipFile(_ownedTabURLs);
+  }
+}
+
+// Matching semantics (exact / normalized / same-origin path-prefix with a segment
+// boundary) live in ownership-match.js, where test/ownership-match.test.mjs locks
+// them — including that owning /org never owns /org-evil, and that the broad
+// "own the whole origin" rule stays dead (it defeated tab-safety entirely).
+export function _isURLOwned(url) {
+  if (!url) return false;
+  _pruneExpiredOwnership();
+  const match = findOwnedMatch(url, _ownedTabURLs);
+  return match !== null ? _touchOwned(match) : false;
+}
+
+// Sentinel persisted when a blank tab (about:blank) is opened by this session.
+// A blank tab has no unique URL to own, but ownership must still survive an MCP
+// process restart (_openedTabs is in-memory only) — otherwise reopening blank
+// tabs falsely trips the "no tabs opened yet" guard. The sentinel is never a
+// real tab URL, so it cannot falsely match a user's page in _isURLOwned().
+export const BLANK_TAB_SENTINEL = "__mcp-blank-tab__";
+
+export function _markBlankTabOpened() {
+  if (!_ownedTabURLs.has(BLANK_TAB_SENTINEL)) {
+    _ownedTabTimestamps.set(BLANK_TAB_SENTINEL, Date.now());
+    _ownedTabURLs.add(BLANK_TAB_SENTINEL);
+    _saveOwnershipFile(_ownedTabURLs);
+  }
+}
+
+export function _addOwnedURL(url) {
+  if (url && url !== "about:blank" && url !== "favorites://") {
+    if (!_ownedTabTimestamps.has(url)) _ownedTabTimestamps.set(url, Date.now());
+    _ownedTabURLs.add(url);
+    _saveOwnershipFile(_ownedTabURLs);
+  }
+}
+
+export function _removeOwnedURL(url) {
+  if (url) {
+    _ownedTabURLs.delete(url);
+    _ownedTabTimestamps.delete(url);
+    _saveOwnershipFile(_ownedTabURLs);
+  }
+}
+
+export function _trackTab(tabIndex, url) {
+  _openedTabs.set(tabIndex, { url: url || "", openedAt: Date.now() });
+  _addOwnedURL(url);
+}
+
+export function _untrackTab(tabIndex) {
+  const info = _openedTabs.get(tabIndex);
+  if (info?.url) _removeOwnedURL(info.url);
+  _openedTabs.delete(tabIndex);
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "response.js",
     "safari.js",
     "ownership-match.js",
+    "ownership-state.js",
     "mcp-helpers.js",
     "injected-validators.js",
     "injected-escape.js",

--- a/test/ownership-state.test.mjs
+++ b/test/ownership-state.test.mjs
@@ -1,0 +1,104 @@
+// Behavioral tests for ownership-state.js — the STATEFUL tab-ownership layer
+// (in-memory sets, on-disk persistence, TTL, blank-tab sentinel, tab tracking).
+// ownership-match.test.mjs covers the pure matching/pruning functions; this file
+// locks the stateful wrappers that index.js (and future src/tools/* modules) rely
+// on to keep the MCP session off the user's tabs.
+//
+// HOME is redirected to a throwaway dir BEFORE importing the module so its file I/O
+// (~/.safari-mcp/owned-tabs.json) never touches the real user's ownership state.
+import test, { after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpHome = mkdtempSync(join(tmpdir(), "smcp-ownership-"));
+process.env.HOME = tmpHome;
+
+const own = await import("../ownership-state.js");
+const { OWNERSHIP_FILE, OWNERSHIP_TTL_MS, BLANK_TAB_SENTINEL } = own;
+
+after(() => {
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+  } catch {}
+});
+
+// Clean module state before each test (the module is a process-wide singleton).
+beforeEach(() => {
+  own._ownedTabURLs.clear();
+  own._ownedTabTimestamps.clear();
+  own._openedTabs.clear();
+});
+
+test("add → isOwned → remove roundtrip (exact URL)", () => {
+  own._addOwnedURL("https://example.com/a");
+  assert.equal(own._isURLOwned("https://example.com/a"), true);
+  own._removeOwnedURL("https://example.com/a");
+  assert.equal(own._isURLOwned("https://example.com/a"), false);
+});
+
+test("about:blank and favorites:// are never owned", () => {
+  own._addOwnedURL("about:blank");
+  own._addOwnedURL("favorites://");
+  assert.equal(own._ownedTabURLs.size, 0);
+});
+
+test("null / empty url is never owned", () => {
+  assert.equal(own._isURLOwned(null), false);
+  assert.equal(own._isURLOwned(""), false);
+  assert.equal(own._isURLOwned(undefined), false);
+});
+
+test("path-segment boundary: owning /org must NOT own /org-evil", () => {
+  own._addOwnedURL("https://host.com/org");
+  // same origin, deeper real path under /org → owned
+  assert.equal(own._isURLOwned("https://host.com/org/page"), true);
+  // sibling that merely shares the /org prefix → NOT owned (the tab-safety hole)
+  assert.equal(own._isURLOwned("https://host.com/org-evil"), false);
+});
+
+test("blank-tab sentinel: marked, persisted, and never matches a real URL", () => {
+  own._markBlankTabOpened();
+  assert.equal(own._ownedTabURLs.has(BLANK_TAB_SENTINEL), true);
+  // the sentinel is not a real URL and must not own a user's page
+  assert.equal(own._isURLOwned("https://example.com/anything"), false);
+  // idempotent — marking again doesn't duplicate
+  own._markBlankTabOpened();
+  assert.equal([...own._ownedTabURLs].filter((u) => u === BLANK_TAB_SENTINEL).length, 1);
+});
+
+test("trackTab owns the URL + records the tab; untrackTab reverses both", () => {
+  own._trackTab(3, "https://example.com/page");
+  assert.equal(own._openedTabs.has(3), true);
+  assert.equal(own._isURLOwned("https://example.com/page"), true);
+  own._untrackTab(3);
+  assert.equal(own._openedTabs.has(3), false);
+  assert.equal(own._isURLOwned("https://example.com/page"), false);
+});
+
+test("ownership persists to owned-tabs.json on disk (atomic write)", () => {
+  own._addOwnedURL("https://persisted.example/x");
+  assert.equal(existsSync(OWNERSHIP_FILE), true);
+  const data = JSON.parse(readFileSync(OWNERSHIP_FILE, "utf8"));
+  assert.ok(Array.isArray(data));
+  assert.ok(data.some((e) => e.url === "https://persisted.example/x" && typeof e.ts === "number"));
+});
+
+test("TTL: an entry older than OWNERSHIP_TTL_MS is pruned and no longer matches", () => {
+  own._addOwnedURL("https://stale.example/y");
+  // backdate its timestamp past the TTL window
+  own._ownedTabTimestamps.set("https://stale.example/y", Date.now() - (OWNERSHIP_TTL_MS + 1000));
+  own._pruneExpiredOwnership();
+  assert.equal(own._ownedTabURLs.has("https://stale.example/y"), false);
+  assert.equal(own._isURLOwned("https://stale.example/y"), false);
+});
+
+test("touch-on-use: asserting against an entry refreshes its timestamp (keeps it alive)", () => {
+  own._addOwnedURL("https://fresh.example/z");
+  // age it to just under the TTL, then assert → should refresh and survive
+  const nearExpiry = Date.now() - (OWNERSHIP_TTL_MS - 1000);
+  own._ownedTabTimestamps.set("https://fresh.example/z", nearExpiry);
+  assert.equal(own._isURLOwned("https://fresh.example/z"), true);
+  assert.ok(own._ownedTabTimestamps.get("https://fresh.example/z") > nearExpiry);
+});


### PR DESCRIPTION
## מה זה
הצעד הבטוח והמחויב הראשון של פיצול `src/tools/*` (ה-follow-up שדוגל ב-PR #37: *"do tests-first — npm test only checks registration"*). מחלץ את שכבת ה-**state של tab-ownership** מ-`index.js` (2508 שורות) למודול ייעודי ונעול-בטסטים.

## למה דווקא זה קודם
ניתוח תלויות הראה ש-96 ה-handlers נסגרים על ~30 משתני state והלפרים מקומיים ב-index.js. **אי אפשר לחלץ אף tool בלי לחלץ קודם את ה-state המשותף.** ה-cluster של tab-ownership הוא היחידה הקוהרנטית והקריטית-אבטחתית ביותר (זה מה ש-v2.13.0 הקשיח בשלושה סבבים), והוא מתחלץ נקי — תלוי רק בעצמו + `ownership-match.js`.

## השינוי
- **`ownership-state.js`** (חדש): `OWNERSHIP_*` consts, `_openedTabs`/`_ownedTabURLs`/`_ownedTabTimestamps`, persistence (`_load`/`_saveOwnershipFile`), TTL (`_pruneExpiredOwnership`/`_touchOwned`), והלפרים (`_isURLOwned`/`_addOwnedURL`/`_removeOwnedURL`/`_trackTab`/`_untrackTab`/`_markBlankTabOpened`). כל ה-state הוא `const` (Map/Set) — mutated לא reassigned — אז ESM live-bindings משמרים זהות אובייקט בין index.js לכל מודול `src/tools/*` עתידי.
- **`index.js`**: −120/+14. הקוד שחולץ → `import` + הערות מצביעות. `_cleanupTabs` (תלוי ב-`safari`) נשאר. ESLint **0 errors** (`no-undef` נקי — אישור סטטי שאף handler לא מתייחס לסמל לא-מיובא).
- **`test/ownership-state.test.mjs`** (חדש, 9 טסטים): נועל את שכבת ה-state שלא היה לה כיסוי קודם — roundtrip, דילוג `about:blank`/`favorites://`, **גבול `/org` ≠ `/org-evil`**, blank-sentinel, trackTab/untrackTab, persistence ל-disk, TTL prune, touch-on-use. `HOME` מופנה ל-temp dir לפני ה-import כדי לא לגעת ב-`~/.safari-mcp` האמיתי.

## אימות
- **npm test: 41/41** (היו 32) — כולל `server starts and lists all registered tools` ו-`registered tools have valid schemas and unique names` → **כל 96 ה-tools עדיין נרשמים**.
- `node --check` נקי, ESLint 0 errors, `npm pack` כולל את `ownership-state.js`.
- התנהגות נשמרה לחלוטין (חילוץ verbatim).

## הבא בתור (לא ב-PR הזה)
חילוץ גשר ה-extension + מוניטור הזיכרון לאותו דפוס, ואז הזזת רישומי ה-tools עצמם ל-`src/tools/<category>.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)