### PR TITLE
feat: דיווח גרסת macOS ב-safari_doctor + סימון טווח 26+ הבעייתי (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`safari_doctor`** now reports the macOS version and flags macOS 26+ (Tahoe), where `CGEvent.postToPid` native clicks/keys can silently no-op even with Accessibility granted (issue #29). Bug reports now carry the single most relevant diagnostic fact, and users on the affected range are steered toward `safari_evaluate` / extension-based clicks for trust-gated forms.
+
 ## [2.14.0] - 2026-06-18
 
 iOS/WebKit web-dev validation tools, a permission-chain diagnostic, and a reliability +

--- a/safari.js
+++ b/safari.js
@@ -4952,6 +4952,31 @@ export async function checkWebKitCompat() {
 // One-shot check of the whole macOS permission + daemon chain, so the
 // "it doesn't work even with permissions granted" failures (#14/#15/#29)
 // surface as one actionable checklist instead of scattered cryptic errors.
+// ========== macOS NATIVE-INPUT COMPAT ==========
+// CGEvent.postToPid (native clicks/keys/hover) can silently no-op on macOS 26+ (Tahoe) even
+// with Accessibility granted — the events are accepted by the API but never cross into Safari's
+// WebContent process (issue #29). doctor() prints the OS version so a bug report carries the
+// single most relevant fact, and flags the known-risky range so users reach for safari_evaluate
+// or extension-based clicks on trust-gated forms instead of chasing a phantom permission grant.
+// Pure (no I/O) so it's unit-tested directly — see test/macos-compat.test.mjs.
+export function macosCompatNote(productVersion) {
+  const raw = String(productVersion ?? "").trim();
+  const major = parseInt(raw.split(".")[0], 10);
+  if (!Number.isFinite(major)) {
+    return {
+      version: "unknown",
+      major: null,
+      risky: false,
+      line: "macOS version: unknown (sw_vers gave no parseable version)",
+    };
+  }
+  const risky = major >= 26;
+  const line = risky
+    ? `macOS ${raw} ⚠ CGEvent native clicks/keys may silently no-op on macOS 26+ even with Accessibility granted (issue #29) — for trust-gated forms prefer safari_evaluate or extension-based safari_click.`
+    : `macOS ${raw} — CGEvent native input supported.`;
+  return { version: raw, major, risky, line };
+}
+
 export async function doctor() {
   const checks = [];
   const add = (ok, label, detail, fix) => checks.push({ ok, label, detail, fix: ok ? null : fix });
@@ -5006,8 +5031,17 @@ export async function doctor() {
   add(idOk, "Helper codesign identity", idDetail,
     `Re-sign: codesign -s - -f --identifier com.achiya-automation.safari-mcp --entitlements safari-helper.entitlements "${helperPath}"`);
 
+  // macOS version — the single most relevant fact for #29-class "native clicks silently fail"
+  // reports. Best-effort: sw_vers is macOS-only and absent in sandboxes/CI, so never block doctor.
+  let osLine = null;
+  try {
+    const { stdout } = await execFileAsync("sw_vers", ["-productVersion"], { timeout: 2000 });
+    osLine = macosCompatNote(stdout).line;
+  } catch { /* sw_vers unavailable — skip the line, the permission checks still stand */ }
+
   const passed = checks.filter((c) => c.ok).length;
   const lines = [`Safari MCP doctor — ${passed}/${checks.length} checks passed`, ""];
+  if (osLine) lines.push(osLine, "");
   for (const c of checks) {
     lines.push(`${c.ok ? "✅" : "❌"} ${c.label}: ${c.detail}`);
     if (!c.ok && c.fix) lines.push(`   → ${c.fix}`);

--- a/test/macos-compat.test.mjs
+++ b/test/macos-compat.test.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for macosCompatNote() — the pure version-classification helper behind the
+ * macOS line that doctor() prints. CGEvent.postToPid native clicks/keys can silently no-op
+ * on macOS 26+ (Tahoe) even with Accessibility granted (issue #29), so doctor() surfaces the
+ * OS version and flags the known-risky range. The parsing/decision logic is pure and lives
+ * here under test; the sw_vers round-trip in doctor() is the only untested glue.
+ *
+ * Run:  node --test test/macos-compat.test.mjs
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { macosCompatNote } from "../safari.js";
+
+test("macOS 26+ is flagged risky and references issue #29", () => {
+  const r = macosCompatNote("26.5");
+  assert.equal(r.major, 26);
+  assert.equal(r.risky, true);
+  assert.match(r.line, /26\.5/);
+  assert.match(r.line, /#29/);
+});
+
+test("macOS 25 and below are reported as supported (not risky)", () => {
+  for (const v of ["15.5", "14.7.2", "25.0", "13.0"]) {
+    const r = macosCompatNote(v);
+    assert.equal(r.risky, false, `${v} must not be risky`);
+    assert.match(r.line, new RegExp(v.replace(/\./g, "\\.")));
+    assert.doesNotMatch(r.line, /#29/, `${v} must not show the #29 warning`);
+  }
+});
+
+test("future majors (27+) stay flagged risky", () => {
+  assert.equal(macosCompatNote("27.0").risky, true);
+  assert.equal(macosCompatNote("30.1.2").risky, true);
+});
+
+test("garbage / missing input degrades gracefully without throwing", () => {
+  for (const bad of ["", "   ", undefined, null, "not-a-version", "abc.def"]) {
+    const r = macosCompatNote(bad);
+    assert.equal(r.risky, false, `${JSON.stringify(bad)} must not be risky`);
+    assert.match(r.line, /unknown/i, `${JSON.stringify(bad)} should report unknown`);
+  }
+});
+
+test("always returns a non-empty single-line string", () => {
+  for (const v of ["26.5", "15.0", "", "garbage"]) {
+    const r = macosCompatNote(v);
+    assert.equal(typeof r.line, "string");
+    assert.ok(r.line.trim().length > 0);
+    assert.doesNotMatch(r.line, /\n/, "line must be single-line (doctor joins on \\n)");
+  }
+});


### PR DESCRIPTION
## מה
`safari_doctor` עכשיו מדווח את גרסת macOS ומסמן את הטווח **26+ (Tahoe)** כמסוכן ל-CGEvent native input.

## למה
ב-macOS 26, `CGEvent.postToPid` עלול לעשות no-op שקט על תוכן WebKit של Safari גם כש-Accessibility מאושר (#29). עד עכשיו `doctor` בדק את כל שרשרת ההרשאות אבל **לא דיווח את גרסת ה-OS** — שזה הנתון הראשון שצריך כשמאבחנים "native clicks לא עובדים למרות שהכול מאושר".

## מה השתנה
- `macosCompatNote()` — פונקציה טהורה שמסווגת גרסה ומסמנת 26+ עם הפניה ל-#29 והכוונה ל-`safari_evaluate` / extension-based clicks לטפסים trust-gated.
- שולבה ב-`doctor()` כ-best-effort (`try/catch` סביב `sw_vers` — לא חוסמת ב-CI/sandbox).

## בדיקות
- 5 unit tests חדשים ל-`macosCompatNote` (parsing, סימון 26+, majors עתידיים, קלט פגום, single-line). כל ה-46 ב-suite עוברים.
- אומת מקצה-לקצה על macOS 26.5.1 — האזהרה מופיעה נכון ב-doctor.