### PR TITLE
fix(helper): keep daemon queue aligned on focus timeouts

### DIFF
--- a/safari.js
+++ b/safari.js
@@ -522,7 +522,14 @@ function _helperHideSafari(timeout = 2000) {
   return _withHelperLock(() => new Promise((resolve) => {
     if (!_helperProc || !_helperProc.stdin?.writable) { resolve(); return; }
     let resolved = false;
-    const timer = setTimeout(() => { if (!resolved) { resolved = true; resolve(); } }, timeout);
+    const timer = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        const idx = _helperQueue.indexOf(cb);
+        if (idx >= 0) _helperQueue[idx] = () => {};
+        resolve();
+      }
+    }, timeout);
     function cb() {
       if (resolved) return;
       resolved = true;
@@ -531,7 +538,12 @@ function _helperHideSafari(timeout = 2000) {
     }
     _helperQueue.push(cb);
     try { _helperProc.stdin.write('{"hideSafari":true}\n'); }
-    catch { clearTimeout(timer); resolve(); }
+    catch {
+      const idx = _helperQueue.indexOf(cb);
+      if (idx >= 0) _helperQueue.splice(idx, 1);
+      clearTimeout(timer);
+      resolve();
+    }
   }));
 }
 
@@ -539,7 +551,14 @@ function _helperActivateApp(bundleId, timeout = 2000) {
   return _withHelperLock(() => new Promise((resolve) => {
     if (!_helperProc || !_helperProc.stdin?.writable) { resolve(); return; }
     let resolved = false;
-    const timer = setTimeout(() => { if (!resolved) { resolved = true; resolve(); } }, timeout);
+    const timer = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        const idx = _helperQueue.indexOf(cb);
+        if (idx >= 0) _helperQueue[idx] = () => {};
+        resolve();
+      }
+    }, timeout);
     function cb() {
       if (resolved) return;
       resolved = true;
@@ -548,7 +567,12 @@ function _helperActivateApp(bundleId, timeout = 2000) {
     }
     _helperQueue.push(cb);
     try { _helperProc.stdin.write(JSON.stringify({ activateApp: bundleId }) + '\n'); }
-    catch { clearTimeout(timer); resolve(); }
+    catch {
+      const idx = _helperQueue.indexOf(cb);
+      if (idx >= 0) _helperQueue.splice(idx, 1);
+      clearTimeout(timer);
+      resolve();
+    }
   }));
 }
 
@@ -998,7 +1022,14 @@ function _helperGetFrontApp(timeout = 2000) {
   return _withHelperLock(() => new Promise((resolve) => {
     if (!_helperProc || !_helperProc.stdin?.writable) { resolve(null); return; }
     let resolved = false;
-    const timer = setTimeout(() => { if (!resolved) { resolved = true; resolve(null); } }, timeout);
+    const timer = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        const idx = _helperQueue.indexOf(cb);
+        if (idx >= 0) _helperQueue[idx] = () => {};
+        resolve(null);
+      }
+    }, timeout);
     function cb(line) {
       if (resolved) return;
       resolved = true;
@@ -1007,7 +1038,12 @@ function _helperGetFrontApp(timeout = 2000) {
     }
     _helperQueue.push(cb);
     try { _helperProc.stdin.write('{"getFrontApp":true}\n'); }
-    catch { clearTimeout(timer); resolve(null); }
+    catch {
+      const idx = _helperQueue.indexOf(cb);
+      if (idx >= 0) _helperQueue.splice(idx, 1);
+      clearTimeout(timer);
+      resolve(null);
+    }
   }));
 }
 


### PR DESCRIPTION
## Summary
- Keep focus-helper timeout callbacks in the helper response queue as no-op consumers so late daemon replies cannot satisfy the next request
- Remove timed-out focus-helper callbacks on write failure so the FIFO helper queue stays aligned
- Prevent Safari MCP doctor/new-tab flows from timing out after a prior focus helper timeout poisons the queue

## Validation
- `npm test` (54 tests passed)
- Direct local validation from the package: Safari MCP doctor 6/6 and `newTab('http://localhost:5173/chat?session=sess-e56dec9bd68cac06')` returned Chat tab info

## Notes
- `npm run lint` currently reports pre-existing lint errors on upstream main unrelated to this change; this patch does not add new lint categories.