### PR TITLE
fix: fail closed when the tracked tab index runs past the end of the window (#54)

### DIFF
--- a/safari.js
+++ b/safari.js
@@ -670,7 +670,7 @@ async function resolveActiveTab() {
     // Parse result — can be "N" (found) or "0:tabCount" (not found)
     const resultStr = String(result);
     if (resultStr.includes(':')) {
-      // Not found — clamp stale index to tabCount
+      // Not found — every exit below fails closed (drops the index); nothing here guesses.
       const tabCount = Number(resultStr.split(':')[1]) || 1;
       _st().lastTabCount = tabCount;
       _st().activeTabURL = null;
@@ -682,8 +682,16 @@ async function resolveActiveTab() {
         return null;
       }
       if (_st().activeTabIndex && _st().activeTabIndex > tabCount) {
-        console.error(`[Safari MCP] Tab ghost proactive fix: index ${_st().activeTabIndex} > tabCount ${tabCount}, clamping to ${tabCount}`);
-        _st().activeTabIndex = tabCount;
+        // Our index is past the end of the window: the user closed a tab or tore one
+        // into its own window, so the index no longer names any tab — least of all ours.
+        // This used to clamp to `tabCount` ("tab ghost proactive fix"), which silently
+        // retargeted us at the LAST tab in the window — the user's. That predates the
+        // identity marker (clamp: Mar 31, marker: v2.8.3 Apr 14) and was the one exit
+        // here that still guessed. Fail closed like the two branches above; callers
+        // re-anchor via _assertNotFallingBackToUserTab's "re-run safari_new_tab" error.
+        console.error(`[Safari MCP] Tab identity lost (index ${_st().activeTabIndex} > tabCount ${tabCount}) — clearing index to avoid targeting the user's tab`);
+        _st().activeTabIndex = null;
+        return null;
       }
       return _st().activeTabIndex;
     }


### PR DESCRIPTION
## What

`resolveActiveTab()` had one exit left that **guessed**. When the tracked index is greater than the window's tab count — the user closed a tab, or tore one into its own window — the code clamped the index to `tabCount`:

```js
// before
if (_st().activeTabIndex && _st().activeTabIndex > tabCount) {
  console.error(`[Safari MCP] Tab ghost proactive fix: index ... clamping to ${tabCount}`);
  _st().activeTabIndex = tabCount;
}
```

`tabCount` is the **last tab in the window**. It is not our tab — it's whatever the user happens to have open there. So the exact moment the code learns it no longer knows where our tab is, it silently retargets the session at a user tab, and logs the words "proactive fix".

This is a fail-open in the safety-critical path, and it's the mechanism behind the incident in #54 (two user tabs navigated away, page state lost).

## Why it survived

`git log -S` dates the clamp to **Mar 31**. The identity marker (`window.name` / `__mcpTabMarker`) landed in **v2.8.3 on Apr 14** — two weeks later.

The clamp is a fossil from the era when the index was genuinely all we had. When v2.8.3 added identity resolution, the two neighbouring branches in the same block were correctly rewired to fail closed:

```js
if (_st().hasOwnedTab && !_st().activeTabMarker) { _st().activeTabIndex = null; return null; }
```

The clamp wasn't, because it doesn't read like an ownership decision — it reads like a bounds check. It has a range test and an error log. It looks like the careful line.

## The change

Fail closed, like every other exit in the function:

```js
// after
if (_st().activeTabIndex && _st().activeTabIndex > tabCount) {
  console.error(`[Safari MCP] Tab identity lost (index ... > tabCount ...) — clearing index to avoid targeting the user's tab`);
  _st().activeTabIndex = null;
  return null;
}
```

No new machinery: the recovery path already exists. `_assertNotFallingBackToUserTab()` turns a null index into a clear *"Tab tracking lost — re-run `safari_new_tab` to recover"* for the caller.

## Trade-off

Sessions that previously got lucky with the clamp will now throw instead. That's the intended direction: for a tool whose entire promise is *"the agent never touches a tab you didn't open"*, an error is the correct answer to "I don't know which tab is mine". A guess is not.

## Notes on #54

This also corrects the root-cause analysis in #54. The issue claimed ownership is positional and proposed adding a sentinel identity — but the sentinel has existed since v2.8.3. The remaining hole was never the missing sentinel; it was this one branch that never started using it. Commenting there separately.

## Test

- `npm test` → 57/57 pass
- `npx eslint .` → 56 errors, identical to `main` (all pre-existing, in browser-context injected files); no new findings

Refs #54