### PR TITLE
fix: exit when stdio clients disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stdio servers now clean up and exit when their client closes stdin without sending a termination signal, preventing stale Safari MCP process trees from accumulating after sessions end.
+
 ## [2.15.6] - 2026-07-23
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -210,19 +210,21 @@ function _startMemoryMonitor() {
 
 // Cleanup on exit
 let _cleaningUp = false;
+async function _shutdown() {
+  if (_cleaningUp) return;
+  _cleaningUp = true;
+  // Restore the user's clipboard synchronously FIRST — if a native paste is mid-flight, its
+  // 2s restore timer would never fire once we exit, leaving the tool's text on the clipboard.
+  try { safari.flushClipboardRestore(); } catch {}
+  // Cap tab cleanup — if the daemon/Safari is wedged at shutdown (exactly when a SIGTERM
+  // tends to arrive), listTabs/closeTab can each block for their full timeout; never let
+  // that hang the exit past 3s.
+  await Promise.race([_cleanupTabs(), new Promise(r => setTimeout(r, 3000))]);
+  process.exit(0);
+}
+
 for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-  process.on(sig, async () => {
-    if (_cleaningUp) return; // Prevent double-exit on rapid signal repeat
-    _cleaningUp = true;
-    // Restore the user's clipboard synchronously FIRST — if a native paste is mid-flight, its
-    // 2s restore timer would never fire once we exit, leaving the tool's text on the clipboard.
-    try { safari.flushClipboardRestore(); } catch {}
-    // Cap tab cleanup — if the daemon/Safari is wedged at shutdown (exactly when a SIGTERM
-    // tends to arrive), listTabs/closeTab can each block for their full timeout; never let
-    // that hang the exit past 3s.
-    await Promise.race([_cleanupTabs(), new Promise(r => setTimeout(r, 3000))]);
-    process.exit(0);
-  });
+  process.on(sig, _shutdown);
 }
 process.on("exit", () => {
   if (_openedTabs.size > 0) {
@@ -2420,4 +2422,12 @@ _startMemoryMonitor();
 
 // Transport is chosen at runtime: default stdio (unchanged), or a shared HTTP instance when
 // SAFARI_MCP_HTTP=1 (many Claude sessions → one process). buildServer is the per-session factory.
-await startTransport(buildServer, process.env);
+const transportHandle = await startTransport(buildServer, process.env);
+
+if (transportHandle.kind === "stdio") {
+  // A client can disappear without delivering a signal. Treat its pipe closing as the stdio
+  // server's lifecycle boundary, while leaving the opt-in HTTP daemon independent of stdin.
+  process.stdin.once("end", _shutdown);
+  process.stdin.once("close", _shutdown);
+  if (process.stdin.readableEnded || process.stdin.destroyed) void _shutdown();
+}

--- a/test/stdio-lifecycle.test.mjs
+++ b/test/stdio-lifecycle.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { test } from "node:test";
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+test("stdio server exits when the client closes stdin", { timeout: 15_000 }, async () => {
+  const child = spawn(process.execPath, ["index.js"], {
+    cwd: process.cwd(),
+    env: { ...process.env, SAFARI_MCP_QUIET: "1" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const exit = once(child, "exit");
+  const stderr = [];
+  child.stderr.on("data", (chunk) => stderr.push(chunk.toString()));
+
+  try {
+    const response = once(child.stdout, "data");
+    child.stdin.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "stdio-lifecycle-test", version: "1.0.0" },
+        },
+      })}\n`
+    );
+
+    await withTimeout(response, 10_000, `server did not initialize\n${stderr.join("")}`);
+    child.stdin.end();
+
+    const [code, signal] = await withTimeout(
+      exit,
+      5_000,
+      `server remained alive after stdin closed\n${stderr.join("")}`
+    );
+    assert.equal(code, 0);
+    assert.equal(signal, null);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+      await withTimeout(exit, 5_000, "server did not stop during test cleanup").catch(() => {
+        child.kill("SIGKILL");
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What

- Reuse one shutdown path for signals and stdio disconnects.
- Exit when a stdio client's input pipe emits `end` or `close`.
- Keep the opt-in HTTP daemon independent of stdin.
- Add an integration test that initializes the MCP server, closes stdin, and asserts a clean exit.

## Why

A stdio client can disappear without forwarding `SIGINT`, `SIGTERM`, or `SIGHUP`. Safari MCP only handled those signals, while its background resources could keep Node alive after stdin closed. Repeated client sessions could therefore accumulate stale `npm`, Node, and helper process trees.

The stdio pipe is the lifecycle boundary for the default transport, so its closure should use the same bounded tab and clipboard cleanup already used for signals. HTTP mode remains a long-lived daemon and does not register these handlers.

## Impact

Stdio sessions now release their Safari MCP process when the client disconnects unexpectedly. Existing signal cleanup behavior and HTTP transport lifetime are unchanged.

## Checks

- `npm test` — 70 tests passed
- `node --test test/stdio-lifecycle.test.mjs`
- `npx eslint index.js test/stdio-lifecycle.test.mjs` — 0 errors
- `npx prettier --check test/stdio-lifecycle.test.mjs CHANGELOG.md`
- `git diff --check`
