### PR TITLE
harden: sanitize child_process call in postinstall.cjs...

### DIFF
--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -3,7 +3,7 @@
 // Skipped silently in CI and when stdout is not a TTY (npm install in scripts).
 
 const path = require("path");
-const { execSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 const fs = require("fs");
 
 const c = {
@@ -31,7 +31,10 @@ function readHelperId(helper) {
     // NOTE: the Identifier= line is only emitted with --verbose. Plain `codesign -d`
     // prints nothing matchable, so the old grep always failed → the early-return never
     // fired and any verify read came back empty (a false "re-sign failed" signal).
-    return execSync(`codesign -d --verbose=2 -- "${helper}" 2>&1 | grep "^Identifier="`, { encoding: "utf8" }).trim();
+    const result = spawnSync("codesign", ["-d", "--verbose=2", "--", helper], { encoding: "utf8" });
+    const output = (result.stdout || "") + (result.stderr || "");
+    const match = output.split("\n").find((l) => l.startsWith("Identifier="));
+    return match ? match.trim() : "";
   } catch { return ""; }
 }
 function ensureCodesign() {
@@ -43,9 +46,11 @@ function ensureCodesign() {
     const current = readHelperId(helper);
     if (current.includes(STABLE_ID)) return;
     const entitlements = path.join(__dirname, "..", "safari-helper.entitlements");
-    const entFlag = fs.existsSync(entitlements) ? `--entitlements "${entitlements}"` : "";
+    const codesignArgs = ["-s", "-", "-f", "--identifier", STABLE_ID];
+    if (fs.existsSync(entitlements)) codesignArgs.push("--entitlements", entitlements);
+    codesignArgs.push(helper);
     // NOTE: do NOT swallow codesign's stderr (the old `2>/dev/null` hid real failures).
-    execSync(`codesign -s - -f --identifier ${STABLE_ID} ${entFlag} "${helper}"`, { stdio: ["ignore", "ignore", "pipe"] });
+    execFileSync("codesign", codesignArgs, { stdio: ["ignore", "ignore", "pipe"] });
     // Verify the re-sign actually took. A SILENT failure here is the #1 cause of native
     // clicks "succeeding" while never reaching the page — the Accessibility grant is keyed
     // to the identifier, so a wrong/unstable identifier breaks it invisibly. Make it loud.


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/postinstall.cjs` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/postinstall.cjs:34` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `helper`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/postinstall.cjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
